### PR TITLE
Remove the redux/vuex/flux recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ In order to implement the user stories listed above, please, **choose one of the
 4. [manage tags](wireframes/04.png)
 5. [filter by tags](wireframes/05.png)
 - Repositories and their tags must be persisted in the user's local storage.
-- The use of libs such as Redux, Vuex or Flux is recommended, but *not* mandatory.
 - Using Docker to configure the environment is recommended, but *not* mandatory.
 
 ## What we will evaluate


### PR DESCRIPTION
## Motivation

- Not always makes sense to use state libraries like redux, especially in small contexts as the challenge. The choice to use or not should be open to the candidate.

## Proposed solution

- Remove the redux/vuex/flux recommendation from the frontend instructions.